### PR TITLE
Updated deprecated Object#timeout to Timeout.timeout

### DIFF
--- a/lib/fourchan/kit/tools.rb
+++ b/lib/fourchan/kit/tools.rb
@@ -112,7 +112,7 @@ module Fourchan
         download_image(thread.op.image_link, options.dup)
 
         begin
-          timeout(options[:timeout]) do
+          Timeout.timeout(options[:timeout]) do
             loop do
               puts "Checking for images" unless options[:quiet]
               new = thread.fetch_replies


### PR DESCRIPTION
In Ruby 2.4.1p111 Object#timeout is deprecated, the recommended substitute is Timeout.timeout.

This PR is just a quick fix to use Timeout.timeout instead of Object#timeout.